### PR TITLE
.gitignore 에 jpa buddy 플러그인의 설정 파일을 무시하도록 룰 추가

### DIFF
--- a/document/fastcampus-project-board/.gitignore
+++ b/document/fastcampus-project-board/.gitignore
@@ -4,6 +4,9 @@
 # Querydsl
 /src/main/generated
 
+### JPA Buddy
+.jpb/
+
 ### Intellij+all ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839


### PR DESCRIPTION
#19 - intellij plugin 중 jpa 작업을 도와주는 jpa buddy
플러그인이 별도 숨김 디렉토리에 파일로 저장하는 듯하여
이를 확인, `.gitignore`에 등록함.